### PR TITLE
replace support link with the new and more useful chat link

### DIFF
--- a/hugo/layouts/partials/langium-mobile-menu.html
+++ b/hugo/layouts/partials/langium-mobile-menu.html
@@ -36,8 +36,8 @@ class="absolute top-0 inset-x-0 p-2 transform origin-top-right md:hidden">
                 <a href="/playground/" class="nav-link-mobile">
                     Playground
                 </a>
-                <a href="https://www.typefox.io/language-engineering/" class="nav-link-mobile">
-                    Support
+                <a href="https://app.gitter.im/#/room/#vscode:gitter.im" class="nav-link-mobile text-emeraldLangium dark:text-emeraldLangium">
+                    Chat
                 </a>
                 <a class='w-10 h-10' target="_blank" href="https://github.com/langium/langium">
                     <img src="/assets/GitHub-Mark-Light-120px-plus.png" alt="GitHub" />

--- a/hugo/layouts/partials/langium-nav.html
+++ b/hugo/layouts/partials/langium-nav.html
@@ -8,9 +8,9 @@
     <a href="/playground/" class="nav-link-desktop">
         Playground
     </a>
-    <a href="https://www.typefox.io/language-engineering/"
+    <a href="https://app.gitter.im/#/room/#vscode:gitter.im"
         class="nav-link-desktop text-emeraldLangium dark:text-emeraldLangium">
-        Support
+        Chat
     </a>
     <a class='w-10 h-10' target="_blank" href="https://github.com/langium/langium">
         <img src="/assets/GitHub-Mark-Light-120px-plus.png" alt="GitHub" />


### PR DESCRIPTION
The support link was a little confusing: it starts with a Langium feature intro that has a URL that links back to the Langium site where we just came from. People clicking "support" will find the chat a lot more handy.