### PR TITLE
Include link for missing monaco styles

### DIFF
--- a/hugo/content/tutorials/langium_and_monaco.md
+++ b/hugo/content/tutorials/langium_and_monaco.md
@@ -128,6 +128,7 @@ Here's the raw contents of the HTML content stored in **src/static/index.html**.
         <meta charset='utf-8'>
         <!-- Page & Monaco styling -->
         <link href="styles.css" rel="stylesheet"/>
+        <link rel="stylesheet" href="./monaco-editor-wrapper/assets/style.css">
         <title>MiniLogo in Langium</title>
     </head>
     <body>


### PR DESCRIPTION
In our docs we were previously missing a link to include the monaco styles in addition to our own. This PR adds that back in, so the user doesn't get an unexpected output.

The existing 'assets' folder & styles contained within are also copied with the bundle in the test environment locally.