### PR TITLE
Support publishing of PR previews to the langium-previews repo

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,7 +61,7 @@ jobs:
           source-dir: ./public
           preview-branch: previews
           umbrella-dir: pr-previews
-          deploy-repository: netomi/langium-previews
+          deploy-repository: eclipse-langium/langium-previews
           token: ${{ secrets.DEPLOY_PREVIEW_TOKEN }}
           action: auto
 
@@ -79,6 +79,6 @@ jobs:
         with:
           preview-branch: previews
           umbrella-dir: pr-previews
-          deploy-repository: netomi/langium-previews
+          deploy-repository: eclipse-langium/langium-previews
           token: ${{ secrets.DEPLOY_PREVIEW_TOKEN }}
           action: auto

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,34 +1,84 @@
 name: Deploy PR previews
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
       - reopened
       - closed
 
-concurrency: preview-${{ github.ref }}
+concurrency: preview-${{ github.head_ref }}
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  deploy-preview:
+  build-preview:
+    if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version: '18'
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Build
         run: |
           npm install
           npm run build
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: "site"
+          path: ./public
+
+  deploy-preview:
+    needs: build-preview
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    environment:
+      name: pull-request-preview
+      url: ${{ steps.deployment.outputs.deployment-url }}
+    steps:
+      # checkout required for pr-preview-action to succeed,
+      # while the content will not be used
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Download the preview page
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: "site"
+          path: ./public
+      - uses: rossjrw/pr-preview-action@183082fd714654433c8e2f6daedbfb4f20f2a94a # v1.4.4
+        id: deployment
         with:
           source-dir: ./public
+          preview-branch: previews
+          umbrella-dir: pr-previews
+          deploy-repository: netomi/langium-previews
+          token: ${{ secrets.DEPLOY_PREVIEW_TOKEN }}
+          action: auto
+
+  # remove the preview page when the PR got closed
+  remove-preview:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      # checkout required for pr-preview-action to succeed,
+      # while the content will not be used
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: rossjrw/pr-preview-action@183082fd714654433c8e2f6daedbfb4f20f2a94a # v1.4.4
+        id: deployment
+        with:
+          preview-branch: previews
+          umbrella-dir: pr-previews
+          deploy-repository: netomi/langium-previews
+          token: ${{ secrets.DEPLOY_PREVIEW_TOKEN }}
+          action: auto

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -2,6 +2,9 @@ baseURL = "/"
 title = "Langium"
 theme = "hugo-geekdoc"
 
+# Required for publishing of previews as they are hosted in subdirs
+relativeURLs = true
+
 # Required to get well formatted code blocks
 disablePathToLower = true
 enableGitInfo = true

--- a/hugo/content/playground/common.ts
+++ b/hugo/content/playground/common.ts
@@ -250,7 +250,7 @@ async function getFreshLangiumWrapper(htmlElement: HTMLElement): Promise<MonacoE
   await langiumWrapper.start(createUserConfig({
     languageId: "langium",
     code: currentGrammarContent,
-    worker: "/playground/libs/worker/langiumServerWorker.js",
+    worker: "./libs/worker/langiumServerWorker.js",
     monarchGrammar: LangiumMonarchContent
   }), htmlElement);
   return langiumWrapper;
@@ -298,7 +298,7 @@ function registerForDocumentChanges(dslClient: any | undefined) {
 async function getLSWorkerForGrammar(grammar: string): Promise<Worker> {
   return new Promise((resolve, reject) => {
     // create & notify the worker to setup w/ this grammar
-    const worker = new Worker("/playground/libs/worker/userServerWorker.js");
+    const worker = new Worker("./libs/worker/userServerWorker.js");
     worker.postMessage({
       type: "startWithGrammar",
       grammar


### PR DESCRIPTION
As requested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4075.

Additional changes that needed to be made for previews to be correctly displayed:

- use relative links when generating the site
- update playground to load additional js files relatively instead of absolutely