### PR TITLE
Update pr-preview-action and pin it

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           name: "site"
           path: ./public
-      - uses: rossjrw/pr-preview-action@v1
+      - uses: rossjrw/pr-preview-action@4668d7cb417ce7067b0b59bc152b1ae1513010de # v1.4.6
         id: deployment
         with:
           source-dir: ./public
@@ -74,7 +74,7 @@ jobs:
       # while the content will not be used
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      - uses: rossjrw/pr-preview-action@v1
+      - uses: rossjrw/pr-preview-action@4668d7cb417ce7067b0b59bc152b1ae1513010de # v1.4.6
         id: deployment
         with:
           preview-branch: previews


### PR DESCRIPTION
This fixes #213 .

After the fixes to the action have been merged and included in a release, we can finally pin the dependency.