### PR TITLE
Added pull-request: write permission to remove-preview job

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -69,6 +69,8 @@ jobs:
   remove-preview:
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       # checkout required for pr-preview-action to succeed,
       # while the content will not be used


### PR DESCRIPTION
This should fix job failures like https://github.com/eclipse-langium/langium-website/actions/runs/7274912030