### PR TITLE
Fix default path to extension entry point

### DIFF
--- a/hugo/content/tutorials/building_an_extension/index.md
+++ b/hugo/content/tutorials/building_an_extension/index.md
@@ -17,7 +17,7 @@ Regardless of what you're working with, you'll want to make sure you have the fo
 {
     ...
     "vscode:prepublish": "npm run esbuild-base -- --minify && npm run lint",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "esbuild ./src/extension/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
     ...
 }
 ```


### PR DESCRIPTION
This page does not currently work out of the box when applied to the project that comes out of `generator-langium` because the location of the extension entry point was moved from `src/extension.ts` to `src/extension/main.ts`. This changes the documentation to match the [current default location](https://github.com/eclipse-langium/langium/blob/main/packages/generator-langium/templates/vscode/src/extension/main.ts).