### PR TITLE
Playground: Customize linking errors

### DIFF
--- a/hugo/content/playground/user-validator.ts
+++ b/hugo/content/playground/user-validator.ts
@@ -1,0 +1,28 @@
+import { AstNode, AstNodeDescription, AstUtils, DefaultDocumentValidator, DefaultLinker, DiagnosticInfo, DocumentState, DocumentValidator, LangiumDocument, LinkingError, LinkingErrorData, ReferenceInfo, ValidationOptions } from "langium";
+import { LangiumServices } from "langium/lsp";
+import { Diagnostic } from "vscode-languageserver";
+
+export class PlaygroundValidator extends DefaultDocumentValidator {
+    constructor(services: LangiumServices) {
+        super(services);
+    }
+    protected override processLinkingErrors(document: LangiumDocument, diagnostics: Diagnostic[], _options: ValidationOptions): void {
+        for (const reference of document.references) {
+            const linkingError = reference.error;
+            if (linkingError) {
+                const info: DiagnosticInfo<AstNode, string> = {
+                    node: linkingError.container,
+                    property: linkingError.property,
+                    index: linkingError.index,
+                    data: {
+                        code: DocumentValidator.LinkingError,
+                        containerType: linkingError.container.$type,
+                        property: linkingError.property,
+                        refText: linkingError.reference.$refText
+                    } satisfies LinkingErrorData
+                };
+                diagnostics.push(this.toDiagnostic('warning', `Linking failed. Please inject a custom scope provider. This is a limitation of the playground. To overcome this issue, please study the learning section in the Langium documentation (original error: ${linkingError.message})`, info));
+            }
+        }
+    }
+};

--- a/hugo/content/playground/user-validator.ts
+++ b/hugo/content/playground/user-validator.ts
@@ -21,7 +21,7 @@ export class PlaygroundValidator extends DefaultDocumentValidator {
                         refText: linkingError.reference.$refText
                     } satisfies LinkingErrorData
                 };
-                diagnostics.push(this.toDiagnostic('warning', `Linking failed. Please inject a custom scope provider. This is a limitation of the playground. To overcome this issue, please study the learning section in the Langium documentation (original error: ${linkingError.message})`, info));
+                diagnostics.push(this.toDiagnostic('warning', `${linkingError.message}\nIn case you want to adjust the linking rules, please consult the learning section in the Langium documentation.`, info));
             }
         }
     }

--- a/hugo/content/playground/user-worker.ts
+++ b/hugo/content/playground/user-worker.ts
@@ -6,9 +6,10 @@
 
 import { NotificationType } from 'vscode-languageserver/browser.js';
 import { DocumentChange, createServerConnection } from './worker-utils.js';
-import { startLanguageServer } from 'langium/lsp';
+import { LangiumServices, startLanguageServer } from 'langium/lsp';
 import { DocumentState } from 'langium';
 import { createServicesForGrammar } from 'langium/grammar';
+import { PlaygroundValidator } from './user-validator.js';
 
 // listen for messages to trigger starting the LS with a given grammar
 addEventListener('message', async (event) => {
@@ -36,11 +37,17 @@ async function startWithGrammar(grammarText: string): Promise<void> {
     // create shared services & serializer for the given grammar grammar
     const { shared, serializer } = await createServicesForGrammar({
         grammar: grammarText,
+        module: {
+            validation: {
+                DocumentValidator: (services: LangiumServices) => new PlaygroundValidator(services) 
+            }
+        },
         sharedModule: {
+    
             lsp: {
                 Connection: () => connection,
             }
-        }
+        },
     });
 
     // listen for validated documents, and send the AST back to the language client


### PR DESCRIPTION
Addresses and closes #226 

For the moment I am using warnings instead of errors for failed linking.

This PR is in draft mode, so I will change the implementation along the discussion inside of the issue.