### PR TITLE
Docs: fixed typo and broken link

### DIFF
--- a/hugo/content/docs/introduction/features.md
+++ b/hugo/content/docs/introduction/features.md
@@ -58,7 +58,7 @@ To express any kind of relationship between elements in your language, you will 
 The process of resolving these references, i.e. identifying what element of your language hides behind a certain name, is called _linking_.
 Performing the linking process in a deterministic manner with a lot of objects in your project requires sound linking design.
 
-Langium accomplishes this feat by using the concept of 'scoping'. You likely know scopes from programming, where some variables are only available from certain scopes:
+Langium accomplishes this feature by using the concept of 'scoping'. You likely know scopes from programming, where some variables are only available from certain scopes:
 
 ```ts
 let x = 42;

--- a/hugo/content/docs/recipes/keywords-as-identifiers/_index.md
+++ b/hugo/content/docs/recipes/keywords-as-identifiers/_index.md
@@ -56,7 +56,7 @@ That's it! (Don't forget to run `npm run langium:generate` after updating the gr
 
 ![screenshot with fixed grammar](fixed-1-grammar.png)
 
-Since the `name` property is used for cross-references by the parser rule for greetings, "Hello" needs to be supported here as well. For that we recommend to introduce a [data type rule](/docs/grammar-language/#data-type-rules) like "PersonID" in the example, since it makes it easier to support more keywords in the future:
+Since the `name` property is used for cross-references by the parser rule for greetings, "Hello" needs to be supported here as well. For that we recommend to introduce a [data type rule](/docs/reference/grammar-language/#data-type-rules) like "PersonID" in the example, since it makes it easier to support more keywords in the future:
 
 ```langium
 Person: 'person' name=PersonID;


### PR DESCRIPTION
Fixed broken link according to the new structure of the documentation.