### PR TITLE
Recipe: File-based symbol import/export

### DIFF
--- a/hugo/content/docs/recipes/scoping/_index.md
+++ b/hugo/content/docs/recipes/scoping/_index.md
@@ -30,3 +30,9 @@ In this guide, we'll look at different scoping kinds and styles and see how we c
 
 Note that these are just example implementations for commonly used scoping methods.
 The scoping API of Langium is designed to be flexible and extensible for any kind of use case.
+
+## Other kinds of scoping
+
+Also mind the following scoping kinds:
+
+- [File-based scoping](/docs/recipes/scoping/file-based)

--- a/hugo/content/docs/recipes/scoping/_index.md
+++ b/hugo/content/docs/recipes/scoping/_index.md
@@ -23,16 +23,11 @@ In general, the way we resolve references is split into three phases of the docu
 - [Scope computation](/docs/reference/document-lifecycle#computing-scopes) determines which elements are reachable from a given position in your document.
 - Finally, the [linking phase](/docs/reference/document-lifecycle#linking) eagerly links each reference within a document to its target using your language's scoping rules.
 
-In this guide, we'll look at different scoping kinds and styles and see how we can achieve them using Langium:
+In this recipe, we'll look at different scoping kinds and styles and see how we can achieve them using Langium:
 
 1. [Qualified Name Scoping](/docs/recipes/scoping/qualified-name)
 2. [Class Member Scoping](/docs/recipes/scoping/class-member)
+3. [File-based scoping](/docs/recipes/scoping/file-based)
 
 Note that these are just example implementations for commonly used scoping methods.
 The scoping API of Langium is designed to be flexible and extensible for any kind of use case.
-
-## Other kinds of scoping
-
-Also mind the following scoping kinds:
-
-- [File-based scoping](/docs/recipes/scoping/file-based)

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -85,7 +85,7 @@ export const HelloWorldModule: Module<HelloWorldServices, PartialLangiumServices
 
 Having done this, will make all persons that are marked with the `export` keyword available to the other files through the index manager.
 
-## Step 3: Bending the cross-reference resolution
+## Step 3: Importing from specific files
 
 The final step is to adjust the cross-reference resolution through overriding the `DefaultScopeProvider.getScope(…)` function. Here is the implementation:
 

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -32,8 +32,7 @@ FileImport: //NEW: imports of the same file are gathered in a list
     '}' 'from' file=STRING; 
 
 PersonImport:
-    person=[Person:ID] ('as' name=ID)?
-    ;
+    person=[Person:ID] ('as' name=ID)?;
 
 Person:
     published?='export'? 'person' name=ID; //NEW: export keyword

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -217,7 +217,7 @@ import { HelloWorldAstType, Model, Person } from "./generated/ast.js";
 import { dirname, join } from "node:path";
 
 export class HelloWorldScopeComputation extends DefaultScopeComputation {
-    override async computeExports(document: LangiumDocument<AstNode>, _cancelToken?: CancellationToken | undefined): Promise<AstNodeDescription[]> {
+    override async computeExports(document: LangiumDocument<AstNode>): Promise<AstNodeDescription[]> {
         const model = document.parseResult.value as Model;
         return model.persons
             .filter(p => p.published)

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -86,7 +86,7 @@ Having done this, will make all persons that are marked with the `export` keywor
 
 ## Step 3: Importing from specific files
 
-The final step is to adjust the cross-reference resolution through overriding the `DefaultScopeProvider.getScope(…)` function. Here is the implementation:
+The final step is to adjust the cross-reference resolution by overriding the `DefaultScopeProvider.getScope(…)` function:
 
 ```typescript
 export class HelloWorldScopeProvider extends DefaultScopeProvider {

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -126,7 +126,7 @@ You noticed the two missing functions? Here is what they have to do.
 The first function (`getExportedPersonsFromGlobalScope(context)`) will take a look at the global scope and return all exported persons respecting the files that were touched by the file imports. Note that we are outputting all persons that are marked with the `export` keyword. The actual name resolution is done internally later by the linker.
 
 ```typescript
-protected getExportedPersonsFromGlobalScope(context: ReferenceInfo): Scope {
+private getExportedPersonsFromGlobalScope(context: ReferenceInfo): Scope {
     //get document for current reference
     const document = AstUtils.getDocument(context.container);
     //get model of document

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -110,9 +110,21 @@ export class HelloWorldScopeProvider extends DefaultScopeProvider {
 }
 ```
 
+Do not forget to add the new service to the `HelloWorldModule`:
+
+```typescript
+export const HelloWorldModule: Module<HelloWorldServices, PartialLangiumServices & HelloWorldAddedServices> = {
+    //...
+    references: {
+        ScopeComputation: (services) => new HelloWorldScopeComputation(services),
+        ScopeProvider: (services) => new HelloWorldScopeProvider(services) //NEW!
+    }
+};
+```
+
 You noticed the two missing functions? Here is what they have to do.
 
-The first function (`getExportedPersonsFromGlobalScope(context)`) will take a look at the global scope and return all exported persons respecting the files that were touched. Not that we are outputting all persons that are marked with the `export` keyword. The actual name resolution is done later by the linker.
+The first function (`getExportedPersonsFromGlobalScope(context)`) will take a look at the global scope and return all exported persons respecting the files that were touched by the file imports. Note that we are outputting all persons that are marked with the `export` keyword. The actual name resolution is done internally later by the linker.
 
 ```typescript
 protected getExportedPersonsFromGlobalScope(context: ReferenceInfo): Scope {
@@ -162,7 +174,7 @@ private getImportedPersonsFromCurrentFile(context: ReferenceInfo) {
 Now, let's test the editor by `npm run build` and starting the extension.
 Try using these two files. The first file contains the Simpsons family.
 
-```
+```plain
 export person Homer
 export person Marge
 person Bart
@@ -172,16 +184,16 @@ export person Maggy
 
 The second file tries to import and greet them.
 
-```
+```plain
 import { 
     Marge,
     Homer,
-    Lisa, //reference error
+    Lisa, //reference error, because not exported
     Maggy as Baby
 } from "persons.hello"
 
-Hello Lisa! //reference error
-Hello Maggy! //reference error
+Hello Lisa! //reference error, because no valid import
+Hello Maggy! //reference error, because name was overwritten with 'Baby'
 Hello Homer!
 Hello Marge!
 Hello Baby!

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -14,7 +14,7 @@ To make things easier I will modify the "Hello World" example from the [learning
 
 ## Step 1: Change the grammar
 
-First thing, we are changing the grammar to support the `export` and the `import` keywords. Here is the modified grammar:
+First off, we are changing the grammar to support the `export` and the `import` statements. Let's take a look at the modified grammar:
 
 ```langium
 grammar HelloWorld

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -62,12 +62,11 @@ The index manager shall get all persons that are marked with the export keyword.
 
 ```typescript
 export class HelloWorldScopeComputation extends DefaultScopeComputation {
-    override async computeExports(document: LangiumDocument<AstNode>, _cancelToken?: CancellationToken | undefined): Promise<AstNodeDescription[]> {
+    override async computeExports(document: LangiumDocument<AstNode>): Promise<AstNodeDescription[]> {
         const model = document.parseResult.value as Model;
         return model.persons
             .filter(p => p.published)
-            .map(p => this.descriptions.createDescription(p, p.name))
-        ;
+            .map(p => this.descriptions.createDescription(p, p.name));
     }
 }
 ```

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -26,9 +26,10 @@ entry Model:
         | greetings+=Greeting
     )*;
 
-FileImport:
-    'import' '{' personImports+=PersonImport (',' personImports+=PersonImport)* '}' 'from' file=STRING
-    ; //NEW: imports of the same file are gathered in a list
+FileImport: //NEW: imports of the same file are gathered in a list
+    'import' '{' 
+        personImports+=PersonImport (',' personImports+=PersonImport)* 
+    '}' 'from' file=STRING; 
 
 PersonImport:
     person=[Person:ID] ('as' name=ID)?

--- a/hugo/content/docs/recipes/scoping/file-based.md
+++ b/hugo/content/docs/recipes/scoping/file-based.md
@@ -5,10 +5,10 @@ weight: 300
 
 ## Goal
 
-Our goal here is to mimic the TypeScript import/export mechanism. By that I mean:
+By default, Langium will always expose all top-level AST elements to the global scope. That means they are visible to all other documents in your workspace. However, a lot of languages are better served with a JavaScript-like `import`/`export` mechanism:
 
-* you can export certain symbols using an `export` keyword from your current file to make it available to the other files
-* you can import certain symbols using the `import` keyword from a different file
+* Using `export` makes a symbol from the current file available for referencing from another file.
+* Using `import` allows to reference symbols for a different file.
 
 To make things easier I will modify the "Hello World" example from the [learning section](/docs/learn/workflow).
 


### PR DESCRIPTION
I added a recipe based on the Hello World example about file-based imports. They are added shortly to the scoping overview page.

I used the "Simpsons" for exporting persons, feel free to suggest some cooler persons.

One might add hints for missing validations or other LSP services, that make this feature more attractive.

Closes #234 