### PR TITLE
Fix preview environment variables

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,6 +31,9 @@ jobs:
         run: |
           npm install
           npm run build
+        env:
+          BASE_URL: /pr-${{ github.event.number }}
+          NODE_ENV: production
       - name: Upload artifact
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:


### PR DESCRIPTION
This change is needed to fix the base url in #249 for creating previews.

Setting these env variables is pointless for old builds, there will be only an effect in #249 .