### PR TITLE
Update imports to match latest

### DIFF
--- a/hugo/content/docs/recipes/builtin-library.md
+++ b/hugo/content/docs/recipes/builtin-library.md
@@ -24,8 +24,9 @@ import {
     AstNode,
     DefaultWorkspaceManager,
     LangiumDocument,
-    LangiumSharedServices
+    LangiumDocumentFactory
 } from "langium";
+import { LangiumSharedServices } from "langium/lsp";
 import { WorkspaceFolder } from 'vscode-languageserver';
 import { URI } from "vscode-uri";
 import { builtinHelloWorld } from './builtins';


### PR DESCRIPTION
LangiumDocumentFactory was missing and LangiumSharedServices has moved to langium/lsp
