### PR TITLE
#256 Fix rendering issue in "Langium's workflow" flowchart

### DIFF
--- a/hugo/content/docs/learn/workflow/_index.md
+++ b/hugo/content/docs/learn/workflow/_index.md
@@ -11,13 +11,13 @@ Be aware of the fact that the possibilities go beyond this simple workflow. For 
 
 {{<mermaid>}}
 flowchart TD
-  A(["1. Install Yeoman"]);
-  B(["2. Scaffold a Langium project"]);
-  C(["3. Write the grammar"]);
-  D(["4. Generate the AST"]);
-  E(["5. Resolve cross-references"]);
-  F(["6. Create validations"]);
-  G(["7. Generate artifacts"]);
+  A(["1.&nbsp;Install Yeoman"]);
+  B(["2.&nbsp;Scaffold a Langium project"]);
+  C(["3.&nbsp;Write the grammar"]);
+  D(["4.&nbsp;Generate the AST"]);
+  E(["5.&nbsp;Resolve cross-references"]);
+  F(["6.&nbsp;Create validations"]);
+  G(["7.&nbsp;Generate artifacts"]);
   H(["Find advanced topics"]);
   A --> B --> C --> D --> E --> F --> G ~~~ H;
   G -- for each additional\ngrammar change --> C;

--- a/hugo/content/docs/learn/workflow/_index.md
+++ b/hugo/content/docs/learn/workflow/_index.md
@@ -20,7 +20,7 @@ flowchart TD
   G(["7.&nbsp;Generate artifacts"]);
   H(["Find advanced topics"]);
   A --> B --> C --> D --> E --> F --> G ~~~ H;
-  G -- for each additional\ngrammar change --> C;
+  G -- for each additional<br/>grammar change --> C;
 
   click A "/docs/learn/workflow/install"
   click B "/docs/learn/workflow/scaffold"


### PR DESCRIPTION
This PR addresses #256. 

The rendering issues might be caused by markdown numbered list recognition in flow chart nodes (e.g. `1. Install Yeoman`).

Escaping the `.` as proposed [here](https://stackoverflow.com/a/50916345), i.e. `1\. Install Yeoman`, did not work for me (Safari 17.6):
![Screenshot 2024-10-29 at 08 49 28](https://github.com/user-attachments/assets/e8267fa8-a59a-419a-8cb3-1dc67fbe9c3c)


As a workaround this PR adds a non-breaking space to prevent numbered lists, e.g. `1.&nbsp;Install Yeoman`.

This seems to fix the rendering issue (tested on Safari 17.6):
![Screenshot 2024-10-29 at 08 40 40](https://github.com/user-attachments/assets/394fe0df-c112-43f6-b55f-cb63e53ae13e)

Additionally, the flow chart node `for each additional\ngrammar change` seems to not render the line break as intended.
Replacing `\n` with `<br/>` results in a proper line break (Safari 17.6):

![Screenshot 2024-10-29 at 08 41 45](https://github.com/user-attachments/assets/3bfab546-a2d4-42c7-9a25-f591a274080a)
