### PR TITLE
Add activation event for builtin library

### DIFF
--- a/hugo/content/docs/recipes/builtin-library.md
+++ b/hugo/content/docs/recipes/builtin-library.md
@@ -175,4 +175,14 @@ clientOptions: LanguageClientOptions = {
     ],
 }
 ```
- **Warning:** It is discouraged to set `scheme` to `'*'`, as, for example, we do not want to build a Git revision when performing a Git diff.
+
+> **Warning:** It is discouraged to set `scheme` to `'*'`, as, for example, we do not want to build a Git revision when performing a Git diff.
+
+Finally, to ensure that this file system provider is registered even before any DSL file is opened, the extension should be activated when any of the library files are opened.
+To do that, use the following `activationEvents` in the `package.json` of your VS Code extension:
+
+```json
+"activationEvents": [
+    "onFileSystem:builtin"
+]
+```


### PR DESCRIPTION
If you close VS Code with a builtin library file open, it won't be reinstated the next time you start VS Code again. Instead, it will display an error, saying that there's no file system provider for the respective URI scheme available. This change adds additional info on how to instruct VS Code to load the file correctly when encountering the URI scheme.