### PR TITLE
Adds in Notifications for Outdated Tutorials

### DIFF
--- a/hugo/content/docs/learn/minilogo/generation_in_the_web.md
+++ b/hugo/content/docs/learn/minilogo/generation_in_the_web.md
@@ -7,7 +7,13 @@ aliases:
 
 {{< toc format=html >}}
 
-*Updated on Oct. 4th, 2023 for usage with monaco-editor-wrapper 3.1.0 & above.*
+{{< notification >}}
+This tutorial is not up to date with the latest versions of Langium & the monaco-editor-wrapper. As a result you'll find these exact instructions, and code samples, will likely not work on current versions. We'll be moving these tutorials over to the monaco-languageclient repo shortly, where they can be better maintained & kept up to date (we'll include a link here once that's done).
+<br/><br/>
+This tutorial was written for Langium 2.0.2 and monaco-editor-wrapper 3.1.0, and won't work for later versions.
+{{< /notification >}}
+
+*Updated on Oct. 4th, 2023 for usage with monaco-editor-wrapper 3.1.0.*
 
 In this tutorial we'll be talking about how to perform generation in the web by listening for document builder notifications. There are multiple ways to hook into Langium to utilize the generator, such as by directly exporting the generator API. However, by listening to notifications from the document builder, we can do this with less code. This lets us quickly integrate new functionality into our existing Langium + Monaco integration, and focus more on what we would want to do with the generated output.
 

--- a/hugo/content/docs/learn/minilogo/langium_and_monaco.md
+++ b/hugo/content/docs/learn/minilogo/langium_and_monaco.md
@@ -7,7 +7,13 @@ aliases:
 
 {{< toc format=html >}}
 
-*Updated on Oct. 4th, 2023 for usage with monaco-editor-wrapper 3.1.0 & above, as well as Langium 2.0.2*
+{{< notification >}}
+This tutorial is not up to date with the latest versions of Langium & the monaco-editor-wrapper. As a result you'll find these exact instructions, and code samples, will likely not work on current versions. We'll be moving these tutorials over to the monaco-languageclient repo shortly, where they can be better maintained & kept up to date (we'll include a link here once that's done).
+<br/><br/>
+This tutorial was written for Langium 2.0.2 and monaco-editor-wrapper 3.1.0, and won't work for later versions.
+{{< /notification >}}
+
+*Updated on Oct. 4th, 2023 for usage with monaco-editor-wrapper 3.1.0, as well as Langium 2.0.2.*
 
 In this tutorial we'll be talking about running Langium in the web with the Monaco editor. If you're not familiar with Monaco, it's the editor that powers VS Code. We're quite fond of it at TypeFox, so we've taken the time to write up this tutorial to explain how to integrate Langium in the web with Monaco, no backend required.
 
@@ -17,8 +23,8 @@ Without further ado, let's jump into getting your web-based Langium experience s
 
 ## Technologies You'll Need
 
-- [Langium](https://www.npmjs.com/package/langium) 2.0.2 or greater
-- [Monaco Editor Wrapper](https://www.npmjs.com/package/monaco-editor-wrapper) 3.1.0 or greater
+- [Langium](https://www.npmjs.com/package/langium) 2.0.2
+- [Monaco Editor Wrapper](https://www.npmjs.com/package/monaco-editor-wrapper) 3.1.0
 - [ESBuild](https://www.npmjs.com/package/esbuild) 0.18.20 or greater
 
 ## Getting your Language Setup for the Web

--- a/hugo/layouts/shortcodes/notification.html
+++ b/hugo/layouts/shortcodes/notification.html
@@ -1,0 +1,14 @@
+<style>
+    .notification {
+    padding: 15px;
+    margin-bottom: 20px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: #000000;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+}
+</style>
+<div class="notification" role="alert">
+    ⚠️   {{ .Inner }}
+</div>


### PR DESCRIPTION
Partially resolves #274 by stating that the web-generation tutorials are not up to date, and makes it clear that later versions from what is stated in the tutorial are not supported. Also added a note that we'll move these 2 guides over to a the monaco-languageclient repo later w/ a relevant link.